### PR TITLE
UAR-2676 Fix csrf tag on questionnaire lookup pages to allow the lookup windows to work correctly.

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/questionnaire/krmsRuleLookup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/questionnaire/krmsRuleLookup.jsp
@@ -27,10 +27,10 @@
         name="ruleId" value="${KrmsRuleLookupForm.ruleId}"/>
     <input type="hidden" id="anchor"
         name="anchor" value="${KrmsRuleLookupForm.anchor}"/>
-        
+        <kul:csrf />
         <label>
 
-       <input type="button" id = "lookupBtn" value="Rule lookup" onclick="window.location.href='${ConfigProperties.rice.server.url}/kr-krad/lookup?methodToCall=start&amp;dataObjectClassName=org.kuali.rice.krms.impl.repository.RuleBo&amp;returnLocation=${ConfigProperties.application.url}/krmsRuleLookup.do&returnFormKey=1&conversionFields=id:ruleId'" />
+       <input type="button" id = "lookupBtn" value="Rule lookup" onclick="window.location.href='${ConfigProperties.rice.server.url}/kr-krad/lookup?methodToCall=start&amp;dataObjectClassName=org.kuali.rice.krms.impl.repository.RuleBo&amp;returnLocation=${ConfigProperties.application.url}/krmsRuleLookup.do&returnFormKey=1&conversionFields=id:ruleId&returnByScript=false&returnTarget=_top'" />
         
             </label><br>
             
@@ -62,5 +62,4 @@
                  
            //      });
             </script>
-    <kul:csrf />
 </html:form>

--- a/src/main/webapp/WEB-INF/jsp/questionnaire/questionLookup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/questionnaire/questionLookup.jsp
@@ -42,6 +42,7 @@
         name="newQuestionSequence" value="${QuestionLookupForm.newQuestionSequence}"/>
 	<input type="hidden" id="anchor"
 		name="anchor" value="${QuestionLookupForm.anchor}"/>
+	<kul:csrf />
 
 
  		<!--  <label>Sponsor Code Search</label> -->
@@ -102,5 +103,4 @@
                  	window.close();
                  }
             </script>
-	<kul:csrf />
 </html:form>

--- a/src/main/webapp/WEB-INF/jsp/questionnaire/questionMultiLookup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/questionnaire/questionMultiLookup.jsp
@@ -38,7 +38,7 @@
 		name="newQuestionId" value="${QuestionLookupForm.newQuestionId}"/>
 	<input type="hidden" id="anchor"
 		name="newQuestionId" value="${QuestionLookupForm.anchor}"/>
-
+		<kul:csrf />
 
  		<!--  <label>Sponsor Code Search</label> -->
    		<label>
@@ -77,5 +77,4 @@
  <%--           
 </kul:page>
   --%>
-	<kul:csrf />
 </html:form>

--- a/src/main/webapp/WEB-INF/jsp/questionnaire/questionReplace.jsp
+++ b/src/main/webapp/WEB-INF/jsp/questionnaire/questionReplace.jsp
@@ -42,6 +42,7 @@
         name="newQuestionSequence" value="${QuestionLookupForm.newQuestionSequence}"/>
 	<input type="hidden" id="anchor"
 		name="anchor" value="${QuestionLookupForm.anchor}"/>
+	<kul:csrf />
 
 
  		<!--  <label>Sponsor Code Search</label> -->
@@ -104,5 +105,4 @@
                  	window.close();
                  }
             </script>
-	<kul:csrf />
 </html:form>


### PR DESCRIPTION
Move csrf tag to allow the questionnaire lookups to work correctly.  Also fix a problem with Rule lookup where the popup window was losing its reference to the parent window.  These fixes were copied from https://github.com/kuali/kc/commit/92e5d506ccd66de581df18fd8963826be3608ac0.