### PR TITLE
UAR-2869 Add back missing csrfToken parameter for getProtocolReviewerTypes()

### DIFF
--- a/src/main/webapp/scripts/kuali_application.js
+++ b/src/main/webapp/scripts/kuali_application.js
@@ -2664,7 +2664,7 @@ function getProtocolReviewerTypes(reviewerData, beanName) {
 			},
 			function( error ) {
 				window.status = errorMessage;	
-			}
+			},$j('[name=csrfToken]').val()
 		);
 }
 /*


### PR DESCRIPTION
Add back missing csrfToken parameter to prevent a null value being sent when calling the jqeuryAjax.do action.